### PR TITLE
Enable EJS challenge solver

### DIFF
--- a/packages/yubal/src/yubal/services/downloader.py
+++ b/packages/yubal/src/yubal/services/downloader.py
@@ -122,6 +122,8 @@ class YTDLPDownloader:
                 "http": lambda n: min(2**n, 30),  # Cap at 30s
                 "fragment": lambda n: min(2**n, 30),
             },
+            # Fetch the EJS challenge solver. See issue #29 https://github.com/guillevc/yubal/issues/29
+            "remote_components": ["ejs:github"],
         }
 
         # Use cookies for age-restricted content, premium quality, etc.


### PR DESCRIPTION
resolves https://github.com/guillevc/yubal/issues/29

Issue: yt-dlp couldn’t solve YouTube’s JS/EJS challenges, so it failed to extract real media URLs and only exposed storyboard image formats, causing “Requested format is not available” errors.

Solution: Enable remote_components (ejs:github) so yt-dlp can fetch the EJS challenge solver, allowing signature/n challenges to be solved and real audio formats to be listed/downloaded.