### PR TITLE
fix(downloader): prioritize configured codec in yt-dlp format selection

### DIFF
--- a/packages/yubal/src/yubal/services/downloader.py
+++ b/packages/yubal/src/yubal/services/downloader.py
@@ -103,8 +103,11 @@ class YTDLPDownloader:
         Returns:
             Dictionary of yt-dlp options.
         """
+        codec = self._config.codec.value
         opts: dict[str, Any] = {
-            "format": "bestaudio/best",
+            "format": (
+                f"bestaudio[ext={codec}]/bestaudio[acodec={codec}]/bestaudio/best"
+            ),
             "outtmpl": str(output_path),
             "color": "never",  # Disable ANSI codes in error messages
             "postprocessors": [


### PR DESCRIPTION
Made a minor change to update the yt-dlp format string in `packages/yubal/src/yubal/services/downloader.py` to prefer the configured audio codec/format (opus, m4a) when selecting the source stream. This avoids unnecessary transcoding when the source is already available in the desired format (e.g., high-quality m4a/aac for Premium).