### PR TITLE
feat: add POST /api/download endpoint

### DIFF
--- a/packages/api/src/yubal_api/api/app.py
+++ b/packages/api/src/yubal_api/api/app.py
@@ -32,6 +32,7 @@ from yubal_api.api.container import Services
 from yubal_api.api.exceptions import register_exception_handlers
 from yubal_api.api.routes import (
     cookies,
+    download,
     health,
     info,
     jobs,
@@ -203,6 +204,7 @@ def create_api_router() -> APIRouter:
     api_router = APIRouter(prefix=f"{base_path}/api")
     api_router.include_router(health.router)
     api_router.include_router(info.router)
+    api_router.include_router(download.router)
     api_router.include_router(jobs.router)
     api_router.include_router(logs.router)
     api_router.include_router(cookies.router)

--- a/packages/api/src/yubal_api/api/routes/download.py
+++ b/packages/api/src/yubal_api/api/routes/download.py
@@ -1,0 +1,55 @@
+"""Download endpoint for triggering a job via a simple query parameter.
+
+Provides a convenient alternative to POST /api/jobs for external tools
+(scripts, browser extensions, etc.) that prefer a URL-based interface
+over a JSON request body.
+"""
+
+from fastapi import APIRouter, Query, status
+
+from yubal_api.api.deps import JobExecutorDep
+from yubal_api.api.exceptions import QueueFullError
+from yubal_api.schemas.jobs import JobCreatedResponse, validate_youtube_music_url
+
+router = APIRouter(tags=["download"])
+
+
+@router.post(
+    "/download",
+    status_code=status.HTTP_201_CREATED,
+    summary="Trigger a download by URL",
+    description=(
+        "Queue a download job for a YouTube or YouTube Music URL. "
+        "Accepts the URL as a query parameter for easy use from scripts "
+        "and browser integrations. Returns 409 if the queue is full."
+    ),
+)
+async def download(
+    job_executor: JobExecutorDep,
+    url: str = Query(
+        description="YouTube or YouTube Music URL (playlist, album, or track)",
+        examples=[
+            "https://music.youtube.com/playlist?list=OLAK5uy_...",
+            "https://www.youtube.com/watch?v=VIDEO_ID",
+        ],
+    ),
+    max_items: int | None = Query(
+        default=None,
+        ge=1,
+        le=10000,
+        description="Maximum number of tracks to download",
+    ),
+) -> JobCreatedResponse:
+    """Queue a download job for the given URL.
+
+    The URL is validated against the same rules as POST /api/jobs.
+    Returns the created job ID which can be tracked via GET /api/jobs
+    or the SSE stream at GET /api/jobs/sse.
+    """
+    validated_url = validate_youtube_music_url(url)
+    job = job_executor.create_and_start_job(validated_url, max_items)
+
+    if job is None:
+        raise QueueFullError()
+
+    return JobCreatedResponse(id=job.id)

--- a/packages/api/tests/test_download.py
+++ b/packages/api/tests/test_download.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+import pytest
+from yubal_api.api.exceptions import QueueFullError
+from yubal_api.api.routes.download import download
+
+
+@pytest.mark.enable_socket
+class TestDownloadEndpoint:
+    @pytest.fixture
+    def mock_executor(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self, mock_executor: MagicMock) -> None:
+        # 4a. Happy path — valid URL, job created
+        mock_job = MagicMock()
+        mock_job.id = "job-123"
+        mock_executor.create_and_start_job.return_value = mock_job
+
+        response = await download(
+            job_executor=mock_executor,
+            url="https://music.youtube.com/playlist?list=OLAK5uy_abcdef...",
+        )
+        assert response.id == "job-123"
+        assert response.message == "Job created"
+
+    @pytest.mark.asyncio
+    async def test_queue_full(self, mock_executor: MagicMock) -> None:
+        # 4b. Queue full
+        mock_executor.create_and_start_job.return_value = None
+
+        with pytest.raises(QueueFullError):
+            await download(
+                job_executor=mock_executor,
+                url="https://music.youtube.com/playlist?list=OLAK5uy_abcdef...",
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_url(self, mock_executor: MagicMock) -> None:
+        # 4c. Invalid URL
+        with pytest.raises(ValueError):
+            await download(
+                job_executor=mock_executor, url="https://example.com/not-youtube"
+            )
+
+    @pytest.mark.asyncio
+    async def test_max_items_forwarded(self, mock_executor: MagicMock) -> None:
+        # 4d. max_items forwarded correctly
+        mock_job = MagicMock()
+        mock_job.id = "job-456"
+        mock_executor.create_and_start_job.return_value = mock_job
+
+        await download(
+            job_executor=mock_executor,
+            url="https://music.youtube.com/watch?v=12345678901",
+            max_items=5,
+        )
+        mock_executor.create_and_start_job.assert_called_once_with(
+            "https://music.youtube.com/watch?v=12345678901", 5
+        )


### PR DESCRIPTION
## Summary

Adds `POST /api/download` as a simpler alternative to `POST /api/jobs`.

### Motivation
The existing `/api/jobs` endpoint requires a JSON body, which is inconvenient
for scripts and browser integrations. This endpoint accepts the URL as a query
parameter, making it easy to trigger downloads with a single curl command:

```bash
curl -X POST "http://localhost:8000/api/download?url=https://music.youtube.com/playlist?list=OLAK5uy_..."
```

### Changes
- New route file: `yubal_api/api/routes/download.py`
- Registered in `app.py` alongside existing routes
- Tests covering happy path, queue full (409), and invalid URL (422)

### Notes
- Reuses `validate_youtube_music_url` and `JobExecutorDep` — no new abstractions
- Response schema is identical to `POST /api/jobs` (`JobCreatedResponse`)
- The job can be tracked via `GET /api/jobs` or the SSE stream