### PR TITLE
feat(m3u): emit #PLAYLIST directive for player display name

### DIFF
--- a/packages/yubal/src/yubal/lib/m3u.py
+++ b/packages/yubal/src/yubal/lib/m3u.py
@@ -14,14 +14,22 @@ from yubal.utils.filename import format_playlist_filename
 logger = logging.getLogger(__name__)
 
 
-def generate_m3u(tracks: list[tuple[TrackMetadata, Path]], m3u_path: Path) -> str:
+def generate_m3u(
+    tracks: list[tuple[TrackMetadata, Path]],
+    m3u_path: Path,
+    playlist_name: str,
+) -> str:
     """Generate M3U playlist content with paths relative to the M3U file location.
 
     Creates an extended M3U format file with track duration and title information.
+    Emits a ``#PLAYLIST:`` directive so players (Navidrome, VLC, Plex, MPD, etc.)
+    display the playlist by its name rather than by the on-disk filename, which
+    includes a collision-avoiding ID suffix.
 
     Args:
         tracks: List of tuples containing (TrackMetadata, file_path) for each track.
         m3u_path: Path where the M3U file will be written (used for relative paths).
+        playlist_name: Human-readable playlist name (used for ``#PLAYLIST:``).
 
     Returns:
         M3U file content as a string.
@@ -30,13 +38,14 @@ def generate_m3u(tracks: list[tuple[TrackMetadata, Path]], m3u_path: Path) -> st
         >>> from pathlib import Path
         >>> tracks = [(track_meta, Path("/music/Artist/2024 - Album/01 - Song.opus"))]
         >>> m3u_path = Path("/music/Playlists/My Playlist.m3u")
-        >>> content = generate_m3u(tracks, m3u_path)
+        >>> content = generate_m3u(tracks, m3u_path, "My Playlist")
         >>> print(content)
         #EXTM3U
+        #PLAYLIST:My Playlist
         #EXTINF:-1,Artist One; Artist Two - Song Title
         ../Artist/2024 - Album/01 - Song.opus
     """
-    lines = ["#EXTM3U"]
+    lines = ["#EXTM3U", f"#PLAYLIST:{playlist_name}"]
 
     for track, file_path in tracks:
         # Get duration from track metadata, use -1 if unknown
@@ -104,7 +113,7 @@ def write_m3u(
     m3u_path = playlists_dir / f"{filename}.m3u"
 
     # Generate and write content
-    content = generate_m3u(tracks, m3u_path)
+    content = generate_m3u(tracks, m3u_path, playlist_name)
     m3u_path.write_text(content, encoding="utf-8")
 
     return m3u_path

--- a/packages/yubal/tests/test_m3u.py
+++ b/packages/yubal/tests/test_m3u.py
@@ -57,9 +57,35 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         assert content.startswith("#EXTM3U\n")
+
+    def test_emits_playlist_directive(
+        self, sample_track: TrackMetadata, tmp_path: Path
+    ) -> None:
+        """Should emit #PLAYLIST: directive as the second line."""
+        track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
+        m3u_path = tmp_path / "_Playlists" / "Liked Songs.m3u"
+
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "Liked Songs")
+
+        lines = content.splitlines()
+        assert lines[0] == "#EXTM3U"
+        assert lines[1] == "#PLAYLIST:Liked Songs"
+
+    def test_playlist_directive_preserves_unicode(
+        self, sample_track: TrackMetadata, tmp_path: Path
+    ) -> None:
+        """Should preserve unicode in #PLAYLIST: directive without sanitization."""
+        track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
+        m3u_path = tmp_path / "_Playlists" / "Musique.m3u"
+
+        content = generate_m3u(
+            [(sample_track, track_path)], m3u_path, "Musique Française"
+        )
+
+        assert "#PLAYLIST:Musique Française" in content
 
     def test_generates_extinf_lines(
         self, sample_track: TrackMetadata, tmp_path: Path
@@ -68,7 +94,7 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         assert "#EXTINF:-1,Radiohead - Airbag" in content
 
@@ -79,7 +105,7 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         # Path should be relative and go up from _Playlists to find Radiohead
         assert "../Radiohead/1997 - OK Computer/01 - Airbag.opus" in content
@@ -99,18 +125,19 @@ class TestGenerateM3U:
             (sample_track, track1_path),
             (sample_track_multiple_artists, track2_path),
         ]
-        content = generate_m3u(tracks, m3u_path)
+        content = generate_m3u(tracks, m3u_path, "My Playlist")
 
         lines = content.strip().split("\n")
-        # Header + 2 tracks * 2 lines each (EXTINF + path)
-        assert len(lines) == 5
+        # Header + #PLAYLIST: + 2 tracks * 2 lines each (EXTINF + path)
+        assert len(lines) == 6
 
         # Verify order
         assert lines[0] == "#EXTM3U"
-        assert lines[1] == "#EXTINF:-1,Radiohead - Airbag"
-        assert "../Radiohead/" in lines[2]
-        assert lines[3] == "#EXTINF:-1,Coldplay / Guest Artist - Sparks"
-        assert "../Coldplay/" in lines[4]
+        assert lines[1] == "#PLAYLIST:My Playlist"
+        assert lines[2] == "#EXTINF:-1,Radiohead - Airbag"
+        assert "../Radiohead/" in lines[3]
+        assert lines[4] == "#EXTINF:-1,Coldplay / Guest Artist - Sparks"
+        assert "../Coldplay/" in lines[5]
 
     def test_multiple_artists_joined_with_slash(
         self, sample_track_multiple_artists: TrackMetadata, tmp_path: Path
@@ -119,17 +146,19 @@ class TestGenerateM3U:
         track_path = tmp_path / "Coldplay" / "2000 - Parachutes" / "03 - Sparks.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track_multiple_artists, track_path)], m3u_path)
+        content = generate_m3u(
+            [(sample_track_multiple_artists, track_path)], m3u_path, "My Playlist"
+        )
 
         assert "#EXTINF:-1,Coldplay / Guest Artist - Sparks" in content
 
     def test_empty_tracks_list(self, tmp_path: Path) -> None:
-        """Should generate valid M3U with only header for empty track list."""
+        """Should generate valid M3U with header and #PLAYLIST: for empty tracks."""
         m3u_path = tmp_path / "_Playlists" / "Empty.m3u"
 
-        content = generate_m3u([], m3u_path)
+        content = generate_m3u([], m3u_path, "Empty")
 
-        assert content == "#EXTM3U\n"
+        assert content == "#EXTM3U\n#PLAYLIST:Empty\n"
 
     def test_content_ends_with_newline(
         self, sample_track: TrackMetadata, tmp_path: Path
@@ -138,7 +167,7 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         assert content.endswith("\n")
 


### PR DESCRIPTION
## Summary

Adds a `#PLAYLIST:<name>` line right after `#EXTM3U` in generated playlist files so players show the playlist's actual name instead of the on-disk filename.

## Problem

The filename suffix is great for avoiding collisions (`Liked Songs [2rSfnZBZ].m3u`), but without a `#PLAYLIST:` directive inside the file, players just use the filename. So in Navidrome (and others) playlists end up looking like "Liked Songs [2rSfnZBZ]" — functional, but the ID makes things feel cluttered.

## Fix

`generate_m3u()` takes a `playlist_name` arg now and emits `#PLAYLIST:<name>` between `#EXTM3U` and the EXTINF lines. `write_m3u()` already had the name handy and just passes it through.

## Compatibility

`#PLAYLIST:` is part of extended M3U and widely supported (VLC, Navidrome, Plex, MPD, foobar2000). Players that don't recognize it just ignore unknown `#` lines, so nothing breaks — no config flag needed.

## Tests

- Added `test_emits_playlist_directive` and `test_playlist_directive_preserves_unicode`.
- Tweaked a couple of existing tests that asserted on specific line counts/indices.
- All 479 tests in `packages/yubal/tests/` pass.