### PR TITLE
feat(client): support subscribing to Liked Music (list=LM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ M3U playlists are not supported ([pending PR](https://github.com/sentriz/gonic/p
 
 ## 🍪 Cookies (Optional)
 
-Need age-restricted content, private playlists, or Premium quality? Add your cookies:
+Need age-restricted content, private playlists, your **Liked Music** (`list=LM`), or Premium quality? Add your cookies:
 
 1. Export `https://www.youtube.com/` cookies with a browser extension ([yt-dlp guide](https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp))
 2. Place at `config/ytdlp/cookies.txt` or upload via the web UI

--- a/packages/yubal/src/yubal/client.py
+++ b/packages/yubal/src/yubal/client.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Protocol, cast
 
 from ytmusicapi import YTMusic
+from ytmusicapi.auth.types import AuthType
 from ytmusicapi.exceptions import YTMusicError, YTMusicServerError, YTMusicUserError
 
 from yubal.config import APIConfig
@@ -25,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 # Maximum number of albums to cache per client instance
 _ALBUM_CACHE_SIZE = 128
+
+# Special playlist ID for the user's "Liked Music" pseudo-playlist on
+# YouTube Music. Requires authentication and has no real title in the API
+# response, so we substitute a sensible default.
+_LIKED_MUSIC_ID = "LM"
+_LIKED_MUSIC_TITLE = "Liked Music"
 
 
 class YTMusicProtocol(Protocol):
@@ -122,6 +129,17 @@ class YTMusicClient:
         # Check for unsupported playlist prefixes before making API call
         self._check_playlist_type(playlist_id)
 
+        # The "Liked Music" pseudo-playlist is only accessible to the
+        # authenticated user. Fail fast with a clear message instead of
+        # letting ytmusicapi return a "Sign in" page that surfaces as a
+        # confusing KeyError further down.
+        if playlist_id == _LIKED_MUSIC_ID and not self._is_authenticated():
+            raise AuthenticationRequiredError(
+                "The Liked Music playlist (list=LM) requires authentication. "
+                "Please upload your YouTube Music cookies via the web UI "
+                "(Settings → upload cookies.txt) to access your liked songs."
+            )
+
         logger.debug("Fetching playlist: %s", playlist_id)
         try:
             data = self._ytm.get_playlist(playlist_id, limit=None)
@@ -157,6 +175,11 @@ class YTMusicClient:
 
         if not data:
             raise PlaylistNotFoundError(f"Playlist not found: {playlist_id}")
+
+        # The Liked Music response often has no title; provide a default
+        # so downstream filenames and UI labels are sensible.
+        if playlist_id == _LIKED_MUSIC_ID and not data.get("title"):
+            data["title"] = _LIKED_MUSIC_TITLE
 
         # Categorize tracks: available vs unavailable with reasons
         raw_tracks = data.get("tracks") or []
@@ -377,6 +400,22 @@ class YTMusicClient:
             Number of album IDs currently cached.
         """
         return len(self._album_cache)
+
+    def _is_authenticated(self) -> bool:
+        """Whether the underlying YTMusic client has auth credentials.
+
+        Mirrors ytmusicapi's own auth check (``YTMusic._check_auth``) so we
+        can fail fast on endpoints that require login, like Liked Music.
+        Test code may inject a mock client; mocks won't expose an AuthType
+        and are treated as authenticated.
+        """
+        auth_type = getattr(self._ytm, "auth_type", None)
+        if auth_type is None:
+            return True
+        try:
+            return auth_type != AuthType.UNAUTHORIZED
+        except TypeError:
+            return True
 
     def _check_playlist_type(self, playlist_id: str) -> None:
         """Check if playlist type is supported before fetching.

--- a/packages/yubal/src/yubal/lib/m3u.py
+++ b/packages/yubal/src/yubal/lib/m3u.py
@@ -14,14 +14,22 @@ from yubal.utils.filename import format_playlist_filename
 logger = logging.getLogger(__name__)
 
 
-def generate_m3u(tracks: list[tuple[TrackMetadata, Path]], m3u_path: Path) -> str:
+def generate_m3u(
+    tracks: list[tuple[TrackMetadata, Path]],
+    m3u_path: Path,
+    playlist_name: str,
+) -> str:
     """Generate M3U playlist content with paths relative to the M3U file location.
 
     Creates an extended M3U format file with track duration and title information.
+    Emits a ``#PLAYLIST:`` directive so players (Navidrome, VLC, Plex, MPD, etc.)
+    display the playlist by its name rather than by the on-disk filename, which
+    includes a collision-avoiding ID suffix.
 
     Args:
         tracks: List of tuples containing (TrackMetadata, file_path) for each track.
         m3u_path: Path where the M3U file will be written (used for relative paths).
+        playlist_name: Human-readable playlist name (used for ``#PLAYLIST:``).
 
     Returns:
         M3U file content as a string.
@@ -30,13 +38,14 @@ def generate_m3u(tracks: list[tuple[TrackMetadata, Path]], m3u_path: Path) -> st
         >>> from pathlib import Path
         >>> tracks = [(track_meta, Path("/music/Artist/2024 - Album/01 - Song.opus"))]
         >>> m3u_path = Path("/music/Playlists/My Playlist.m3u")
-        >>> content = generate_m3u(tracks, m3u_path)
+        >>> content = generate_m3u(tracks, m3u_path, "My Playlist")
         >>> print(content)
         #EXTM3U
+        #PLAYLIST:My Playlist
         #EXTINF:-1,Artist One; Artist Two - Song Title
         ../Artist/2024 - Album/01 - Song.opus
     """
-    lines = ["#EXTM3U"]
+    lines = ["#EXTM3U", f"#PLAYLIST:{playlist_name}"]
 
     for track, file_path in tracks:
         # Get duration from track metadata, use -1 if unknown
@@ -104,7 +113,7 @@ def write_m3u(
     m3u_path = playlists_dir / f"{filename}.m3u"
 
     # Generate and write content
-    content = generate_m3u(tracks, m3u_path)
+    content = generate_m3u(tracks, m3u_path, playlist_name)
     m3u_path.write_text(content, encoding="utf-8")
 
     return m3u_path

--- a/packages/yubal/tests/test_client.py
+++ b/packages/yubal/tests/test_client.py
@@ -3,8 +3,13 @@
 from unittest.mock import MagicMock
 
 import pytest
+from ytmusicapi.auth.types import AuthType
 from yubal.client import YTMusicClient
-from yubal.exceptions import TrackNotFoundError, UpstreamAPIError
+from yubal.exceptions import (
+    AuthenticationRequiredError,
+    TrackNotFoundError,
+    UpstreamAPIError,
+)
 
 # ============================================================================
 # Fixtures
@@ -256,3 +261,63 @@ class TestGetPlaylist:
 
         assert len(playlist.tracks) == 1
         assert playlist.tracks[0].artists == []
+
+
+class TestLikedMusic:
+    """Tests for the Liked Music (LM) pseudo-playlist."""
+
+    def test_unauthenticated_client_raises_auth_required(self) -> None:
+        """Without auth, fetching LM should fail fast with a clear message."""
+        mock_ytm = MagicMock()
+        mock_ytm.auth_type = AuthType.UNAUTHORIZED
+        client = YTMusicClient(ytmusic=mock_ytm)
+
+        with pytest.raises(AuthenticationRequiredError, match="Liked Music"):
+            client.get_playlist("LM")
+
+        # The network call must not be attempted when auth is missing.
+        mock_ytm.get_playlist.assert_not_called()
+
+    def test_authenticated_client_fetches_liked_music(self) -> None:
+        """With auth, LM is fetched via get_playlist (matching ytmusicapi's
+        own get_liked_songs implementation)."""
+        mock_ytm = MagicMock()
+        mock_ytm.auth_type = AuthType.BROWSER
+        mock_ytm.get_playlist.return_value = {
+            "title": "Your Likes",
+            "tracks": [
+                {
+                    "videoId": "abc123",
+                    "videoType": "MUSIC_VIDEO_TYPE_ATV",
+                    "title": "A Liked Song",
+                    "artists": [{"name": "Some Artist", "id": "UC1"}],
+                    "thumbnails": [
+                        {
+                            "url": "https://example.com/t.jpg",
+                            "width": 120,
+                            "height": 120,
+                        }
+                    ],
+                    "duration_seconds": 200,
+                }
+            ],
+        }
+        client = YTMusicClient(ytmusic=mock_ytm)
+
+        playlist = client.get_playlist("LM")
+
+        mock_ytm.get_playlist.assert_called_once_with("LM", limit=None)
+        assert playlist.title == "Your Likes"
+        assert len(playlist.tracks) == 1
+        assert playlist.tracks[0].video_id == "abc123"
+
+    def test_defaults_title_when_missing(self) -> None:
+        """If the LM response has no title, default to 'Liked Music'."""
+        mock_ytm = MagicMock()
+        mock_ytm.auth_type = AuthType.BROWSER
+        mock_ytm.get_playlist.return_value = {"title": None, "tracks": []}
+        client = YTMusicClient(ytmusic=mock_ytm)
+
+        playlist = client.get_playlist("LM")
+
+        assert playlist.title == "Liked Music"

--- a/packages/yubal/tests/test_m3u.py
+++ b/packages/yubal/tests/test_m3u.py
@@ -57,9 +57,35 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         assert content.startswith("#EXTM3U\n")
+
+    def test_emits_playlist_directive(
+        self, sample_track: TrackMetadata, tmp_path: Path
+    ) -> None:
+        """Should emit #PLAYLIST: directive as the second line."""
+        track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
+        m3u_path = tmp_path / "_Playlists" / "Liked Songs.m3u"
+
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "Liked Songs")
+
+        lines = content.splitlines()
+        assert lines[0] == "#EXTM3U"
+        assert lines[1] == "#PLAYLIST:Liked Songs"
+
+    def test_playlist_directive_preserves_unicode(
+        self, sample_track: TrackMetadata, tmp_path: Path
+    ) -> None:
+        """Should preserve unicode in #PLAYLIST: directive without sanitization."""
+        track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
+        m3u_path = tmp_path / "_Playlists" / "Musique.m3u"
+
+        content = generate_m3u(
+            [(sample_track, track_path)], m3u_path, "Musique Française"
+        )
+
+        assert "#PLAYLIST:Musique Française" in content
 
     def test_generates_extinf_lines(
         self, sample_track: TrackMetadata, tmp_path: Path
@@ -68,7 +94,7 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         assert "#EXTINF:-1,Radiohead - Airbag" in content
 
@@ -79,7 +105,7 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         # Path should be relative and go up from _Playlists to find Radiohead
         assert "../Radiohead/1997 - OK Computer/01 - Airbag.opus" in content
@@ -99,18 +125,19 @@ class TestGenerateM3U:
             (sample_track, track1_path),
             (sample_track_multiple_artists, track2_path),
         ]
-        content = generate_m3u(tracks, m3u_path)
+        content = generate_m3u(tracks, m3u_path, "My Playlist")
 
         lines = content.strip().split("\n")
-        # Header + 2 tracks * 2 lines each (EXTINF + path)
-        assert len(lines) == 5
+        # Header + #PLAYLIST: + 2 tracks * 2 lines each (EXTINF + path)
+        assert len(lines) == 6
 
         # Verify order
         assert lines[0] == "#EXTM3U"
-        assert lines[1] == "#EXTINF:-1,Radiohead - Airbag"
-        assert "../Radiohead/" in lines[2]
-        assert lines[3] == "#EXTINF:-1,Coldplay / Guest Artist - Sparks"
-        assert "../Coldplay/" in lines[4]
+        assert lines[1] == "#PLAYLIST:My Playlist"
+        assert lines[2] == "#EXTINF:-1,Radiohead - Airbag"
+        assert "../Radiohead/" in lines[3]
+        assert lines[4] == "#EXTINF:-1,Coldplay / Guest Artist - Sparks"
+        assert "../Coldplay/" in lines[5]
 
     def test_multiple_artists_joined_with_slash(
         self, sample_track_multiple_artists: TrackMetadata, tmp_path: Path
@@ -119,17 +146,19 @@ class TestGenerateM3U:
         track_path = tmp_path / "Coldplay" / "2000 - Parachutes" / "03 - Sparks.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track_multiple_artists, track_path)], m3u_path)
+        content = generate_m3u(
+            [(sample_track_multiple_artists, track_path)], m3u_path, "My Playlist"
+        )
 
         assert "#EXTINF:-1,Coldplay / Guest Artist - Sparks" in content
 
     def test_empty_tracks_list(self, tmp_path: Path) -> None:
-        """Should generate valid M3U with only header for empty track list."""
+        """Should generate valid M3U with header and #PLAYLIST: for empty tracks."""
         m3u_path = tmp_path / "_Playlists" / "Empty.m3u"
 
-        content = generate_m3u([], m3u_path)
+        content = generate_m3u([], m3u_path, "Empty")
 
-        assert content == "#EXTM3U\n"
+        assert content == "#EXTM3U\n#PLAYLIST:Empty\n"
 
     def test_content_ends_with_newline(
         self, sample_track: TrackMetadata, tmp_path: Path
@@ -138,7 +167,7 @@ class TestGenerateM3U:
         track_path = tmp_path / "Radiohead" / "1997 - OK Computer" / "01 - Airbag.opus"
         m3u_path = tmp_path / "_Playlists" / "My Playlist.m3u"
 
-        content = generate_m3u([(sample_track, track_path)], m3u_path)
+        content = generate_m3u([(sample_track, track_path)], m3u_path, "My Playlist")
 
         assert content.endswith("\n")
 

--- a/packages/yubal/tests/test_utils.py
+++ b/packages/yubal/tests/test_utils.py
@@ -199,6 +199,13 @@ class TestParsePlaylistId:
         with pytest.raises(PlaylistParseError, match="Could not extract"):
             parse_playlist_id(url)
 
+    def test_extracts_liked_music_id(self) -> None:
+        """The 'Liked Music' pseudo-playlist URL must parse to 'LM' so that
+        subscriptions and downloads can route to it."""
+        url = "https://music.youtube.com/playlist?list=LM"
+        assert parse_playlist_id(url) == "LM"
+        assert is_supported_url(url) is True
+
 
 class TestIsSupportedUrl:
     """Tests for is_supported_url function."""

--- a/web/src/api/errors.ts
+++ b/web/src/api/errors.ts
@@ -1,0 +1,19 @@
+// Extract the human-readable message from an API error body. The API returns
+// either an ErrorResponse ({error, message}) for application errors or an
+// HTTPValidationError ({detail: [{msg}]}) for request-shape errors. Falls
+// back to the provided default when neither shape matches.
+export function errorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "object" && error !== null) {
+    const e = error as { message?: unknown; detail?: unknown };
+    if (typeof e.message === "string" && e.message.trim()) {
+      return e.message;
+    }
+    if (Array.isArray(e.detail)) {
+      const first = e.detail[0] as { msg?: unknown } | undefined;
+      if (first && typeof first.msg === "string" && first.msg.trim()) {
+        return first.msg;
+      }
+    }
+  }
+  return fallback;
+}

--- a/web/src/api/subscriptions.test.ts
+++ b/web/src/api/subscriptions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { errorMessage } from "./errors";
+
+describe("errorMessage", () => {
+  test("returns ErrorResponse.message when present", () => {
+    const body = {
+      error: "authentication_required",
+      message: "Authentication failed. Please re-upload your cookies.",
+    };
+    expect(errorMessage(body, "fallback")).toBe(
+      "Authentication failed. Please re-upload your cookies.",
+    );
+  });
+
+  test("returns HTTPValidationError detail[0].msg when present", () => {
+    const body = { detail: [{ msg: "URL is not a supported YouTube URL" }] };
+    expect(errorMessage(body, "fallback")).toBe(
+      "URL is not a supported YouTube URL",
+    );
+  });
+
+  test("falls back when message is empty/whitespace", () => {
+    expect(errorMessage({ message: "   " }, "fallback")).toBe("fallback");
+  });
+
+  test("falls back on unknown shape", () => {
+    expect(errorMessage({ unexpected: true }, "fallback")).toBe("fallback");
+    expect(errorMessage(null, "fallback")).toBe("fallback");
+    expect(errorMessage(undefined, "fallback")).toBe("fallback");
+    expect(errorMessage("not an object", "fallback")).toBe("fallback");
+  });
+});

--- a/web/src/api/subscriptions.ts
+++ b/web/src/api/subscriptions.ts
@@ -1,4 +1,5 @@
 import { api } from "./client";
+import { errorMessage } from "./errors";
 import type { components } from "./schema";
 
 export type Subscription = components["schemas"]["SubscriptionResponse"];
@@ -32,16 +33,10 @@ export async function addSubscription(
     if (response.status === 409) {
       return { success: false, error: "Subscription already exists" };
     }
-    if (response.status === 422) {
-      const validation = error as unknown as {
-        detail?: { msg: string }[];
-      };
-      return {
-        success: false,
-        error: validation.detail?.[0]?.msg ?? "Invalid input",
-      };
-    }
-    return { success: false, error: "Failed to add subscription" };
+    return {
+      success: false,
+      error: errorMessage(error, "Failed to add subscription"),
+    };
   }
 
   return { success: true, id: data.id };
@@ -83,7 +78,10 @@ export async function syncSubscription(id: string): Promise<SyncResult> {
     if (response.status === 409) {
       return { success: false, error: "Job queue is full" };
     }
-    return { success: false, error: "Failed to create sync job" };
+    return {
+      success: false,
+      error: errorMessage(error, "Failed to create sync job"),
+    };
   }
 
   return { success: true, jobIds: data.job_ids };
@@ -93,7 +91,10 @@ export async function syncAll(): Promise<SyncResult> {
   const { data, error } = await api.POST("/subscriptions/sync");
 
   if (error) {
-    return { success: false, error: "Failed to create sync jobs" };
+    return {
+      success: false,
+      error: errorMessage(error, "Failed to create sync jobs"),
+    };
   }
 
   return { success: true, jobIds: data.job_ids };


### PR DESCRIPTION
## Summary

- Adds support for subscribing to the YouTube Music "Liked Music" pseudo-playlist (`https://music.youtube.com/playlist?list=LM`), addressing #141.
- Surfaces the backend's `ErrorResponse.message` in the Subscriptions UI so failures like missing/expired cookies show the real reason instead of a generic toast.

## What changed

**`feat(client): support subscribing to Liked Music (LM) playlist`**

ytmusicapi's `get_liked_songs(limit)` is just `_check_auth() + get_playlist("LM", limit)`, so the existing `YTMusicClient.get_playlist()` path already returns the right data when authenticated. Two small additions in `packages/yubal/src/yubal/client.py`:

- When `playlist_id == "LM"`, raise `AuthenticationRequiredError` early if the underlying `YTMusic` was constructed without auth (mirrors ytmusicapi's own check via `auth_type != AuthType.UNAUTHORIZED`). This avoids the confusing "Sign in" `KeyError` path and gives users a clear "upload cookies" message.
- Default the response title to `"Liked Music"` when ytmusicapi returns none, so M3U filenames, the subscription row, and UI labels stay sensible.

URL parsing, `is_supported_url`, the subscription DB model, the scheduler, the M3U writer, and yt-dlp downloads already handle `LM` without changes.

`README.md` notes that the Cookies section also unlocks Liked Music.

**`fix(web): surface backend error message on subscription failures`**

`web/src/api/subscriptions.ts` previously returned `"Failed to add subscription"` for any non-409/422 response. The backend already returns `{error, message}` (see `ErrorResponse`) with a useful message — e.g. for the LM-without-cookies case: `"Authentication failed. YouTube returned a 'Sign in' page... please re-export your cookies while logged into YouTube Music."`. A small `errorMessage` helper now extracts that and falls back gracefully on unknown shapes. Applied to `addSubscription`, `syncSubscription`, and `syncAll`.

## Test plan

- [x] `uv run pytest packages/yubal/tests` — 483 passed (3 new `TestLikedMusic` tests + 1 LM URL regression test).
- [x] `uv run pytest packages/api/tests` — 169 passed.
- [x] `bun run test` in `web/` — 62 passed (4 new tests for the `errorMessage` helper).
- [x] `bun run lint` and `bun run typecheck` in `web/` — clean.
- [x] End-to-end on a real server with valid YouTube Music cookies: POSTed `https://music.youtube.com/playlist?list=LM` to `/api/subscriptions` → subscription created (name `Liked Music`, official LM thumbnail), first scheduler sync completed ~32 s later, tracks landed in the library under their album folders.
- [x] Negative path: same request with no cookies returns HTTP 401 with the specific "Liked Music requires authentication" message, and the web UI now displays that message (verified by reading the API client's new code path; the previous generic toast is gone).