### PR TITLE
fix: don't skip tracks with missing videoType from API

### DIFF
--- a/packages/yubal/src/yubal/services/extractor.py
+++ b/packages/yubal/src/yubal/services/extractor.py
@@ -562,6 +562,16 @@ class MetadataExtractorService:
                 if metadata is not None:
                     return metadata, None
 
+            # Tracks whose videoType field is absent from the API response
+            # are still valid and downloadable. Treat them like UGC so they
+            # flow through when YUBAL_DOWNLOAD_UGC is enabled.
+            if not track.video_type:
+                metadata = self._create_fallback_metadata(
+                    track, VideoType.UGC, match_result=MatchResult.UNOFFICIAL
+                )
+                if metadata is not None:
+                    return metadata, None
+
             return None, SkipReason.UGC if is_ugc else SkipReason.UNSUPPORTED_VIDEO_TYPE
 
         album_id = track.album.id if track.album else None

--- a/packages/yubal/src/yubal/services/extractor.py
+++ b/packages/yubal/src/yubal/services/extractor.py
@@ -93,7 +93,9 @@ class MetadataExtractorService:
 
         Args:
             client: YouTube Music API client for fetching playlist/album data.
-            download_ugc: If True, extract UGC tracks as unofficial instead of skipping.
+            download_ugc: If True, extract UGC tracks as unofficial instead of
+                skipping them. Also covers tracks whose video type is missing
+                from the API.
         """
         self._client = client
         self._download_ugc = download_ugc
@@ -520,7 +522,8 @@ class MetadataExtractorService:
         """Extract and enrich metadata for a single track.
 
         This is the core per-track processing pipeline:
-        1. Validate video type (skip unsupported types like UGC videos)
+        1. Validate video type (skip unsupported types; extract UGC and untyped
+           tracks as unofficial when download_ugc is enabled)
         2. Find album info (from track data or search)
         3. Fetch full album details from YouTube Music
         4. Build enriched metadata with album info, or fallback to basic data
@@ -555,17 +558,11 @@ class MetadataExtractorService:
                 except ValueError:
                     pass
 
-            if is_ugc and self._download_ugc:
-                metadata = self._create_fallback_metadata(
-                    track, VideoType.UGC, match_result=MatchResult.UNOFFICIAL
-                )
-                if metadata is not None:
-                    return metadata, None
-
-            # Tracks whose videoType field is absent from the API response
-            # are still valid and downloadable. Treat them like UGC so they
-            # flow through when YUBAL_DOWNLOAD_UGC is enabled.
-            if not track.video_type:
+            # The API omits videoType for some tracks that still have a valid
+            # videoId and play fine. Most are user uploads with no tagging, so
+            # treat them like explicit UGC: extract when UGC downloads are on,
+            # skip otherwise.
+            if (is_ugc or not track.video_type) and self._download_ugc:
                 metadata = self._create_fallback_metadata(
                     track, VideoType.UGC, match_result=MatchResult.UNOFFICIAL
                 )

--- a/packages/yubal/tests/test_extractor.py
+++ b/packages/yubal/tests/test_extractor.py
@@ -1782,6 +1782,56 @@ class TestUGCDownload:
         assert tracks[0].video_id == "ugc123"
         assert tracks[0].album == "User Upload"  # Uses title as album for singles
 
+    def _make_untyped_playlist(self) -> Playlist:
+        """Create a playlist whose track has no videoType field."""
+        return Playlist.model_validate(
+            {
+                "tracks": [
+                    {
+                        "videoId": "untyped123",
+                        # No videoType field — omitted by the API
+                        "title": "Untagged Upload",
+                        "artists": [{"name": "Some User"}],
+                        "thumbnails": [
+                            {"url": "https://t.jpg", "width": 120, "height": 90}
+                        ],
+                        "duration_seconds": 180,
+                    }
+                ]
+            }
+        )
+
+    def test_missing_video_type_skipped_when_download_ugc_disabled(self) -> None:
+        """Should skip untyped tracks when download_ugc is False.
+
+        The API omitted videoType, so nothing proves the track is UGC. It
+        reports SkipReason.UNSUPPORTED_VIDEO_TYPE instead.
+        """
+        playlist = self._make_untyped_playlist()
+        mock = MockYTMusicClient(playlist=playlist, album=None, search_results=[])
+        service = MetadataExtractorService(mock, download_ugc=False)
+
+        metadata, skip_reason = service._extract_single_track(playlist.tracks[0])
+        assert metadata is None
+        assert skip_reason is SkipReason.UNSUPPORTED_VIDEO_TYPE
+
+    def test_missing_video_type_extracted_when_download_ugc_enabled(self) -> None:
+        """Should extract untyped tracks as unofficial when download_ugc is True."""
+        playlist = self._make_untyped_playlist()
+        mock = MockYTMusicClient(playlist=playlist, album=None, search_results=[])
+        service = MetadataExtractorService(mock, download_ugc=True)
+
+        tracks = extract_all(service, "https://music.youtube.com/playlist?list=PLtest")
+
+        assert len(tracks) == 1
+        assert tracks[0].match_result == MatchResult.UNOFFICIAL
+        assert tracks[0].title == "Untagged Upload"
+        assert tracks[0].source_video_id == "untyped123"
+        assert tracks[0].video_type == VideoType.UGC
+        assert tracks[0].omv_video_id is None
+        assert tracks[0].atv_video_id is None
+        assert tracks[0].video_id == "untyped123"
+
     def test_ugc_mixed_with_supported_types(self) -> None:
         """Should extract both supported and UGC tracks when enabled."""
         playlist = Playlist.model_validate(


### PR DESCRIPTION
Closes #166

### Problem

Tracks whose `videoType` field is absent (`null`) in the YouTube Music API response are skipped as "unsupported video type", even though they have valid `videoId` and `isAvailable: true`.

**Example:** playlist `PLSJ8iGpQtYU8me1ZkQWfw2TZBybZoLijH` — track 1 has `videoType: null` while tracks 2–7 are `MUSIC_VIDEO_TYPE_UGC`. Only tracks 2–7 sync; track 1 is silently dropped.

### Root Cause

`_extract_single_track` in `extractor.py` treats `video_type is None` uniformly — both genuinely unsupported video types AND the case where the API simply omits the field. The UGC fallback only fires when `track.video_type` is a non-null string, so null-typed tracks fall through to the `UNSUPPORTED_VIDEO_TYPE` skip.

### Fix

When `track.video_type` is `None` (missing from the API), create fallback metadata with `VideoType.UGC` / `MatchResult.UNOFFICIAL` — same treatment as explicit UGC tracks. These are typically user-uploaded tracks that lack proper tagging. They flow through when `YUBAL_DOWNLOAD_UGC` is enabled; when disabled, `_create_fallback_metadata` rejects them as before. No behavioral change for users with UGC downloads off.

### Testing

Tested on the playlist above: all 7 tracks now sync successfully.